### PR TITLE
Bump safe-eval to fix security vuln

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7241,9 +7241,9 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-eval": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/safe-eval/-/safe-eval-0.3.0.tgz",
-      "integrity": "sha1-Bs4RHuvZwYWrr/AI7A/P/Fxb4Aw="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/safe-eval/-/safe-eval-0.4.1.tgz",
+      "integrity": "sha512-wmiu4RSYVZ690RP1+cv/LxfPK1dIlEN35aW7iv4SMYdqDrHbkll4+NJcHmKm7PbCuI1df1otOcPwgcc2iFR85g=="
     },
     "safe-regex": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@vitalets/google-translate-token": "^1.0.2",
     "configstore": "^2.0.0",
     "got": "^6.3.0",
-    "safe-eval": "^0.3.0"
+    "safe-eval": "^0.4.1"
   },
   "devDependencies": {
     "ava": "^0.15.2",


### PR DESCRIPTION
[`safe-eval` v0.3.0 has a critical security vulnerability](https://www.npmjs.com/advisories/337).