### PR TITLE
Update languages.js and index.js to fix Punjabi translations, add support for both 'zh' and 'zh-cn' Simplified Chinese and both 'he' and 'iw' Hebrew translations, and allow for translation requests from any language URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,6 @@ function translate(text, opts) {
     opts.to = languages.getCode(opts.to);
 
     return token.get(text).then(function (token) {
-        var url = 'https://translate.google.com/translate_a/single';
         var data = {
             client: opts.client || 't',
             sl: opts.from,

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var querystring = require('querystring');
 
+var url = require('url');
 var got = require('got');
 var token = require('@vitalets/google-translate-token');
 
@@ -46,7 +47,7 @@ function translate(text, opts) {
         };
         data[token.name] = token.value;
 
-        return url + '?' + querystring.stringify(data);
+        return url.resolve(token.url, '/translate_a/single?' + querystring.stringify(data));
     }).then(function (url) {
         return got(url).then(function (res) {
             var result = {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var querystring = require('querystring');
 
-var url = require('url');
 var got = require('got');
 var token = require('@vitalets/google-translate-token');
 
@@ -30,6 +29,8 @@ function translate(text, opts) {
     opts.to = languages.getCode(opts.to);
 
     return token.get(text).then(function (token) {
+        var tld = 'com';
+        var url = 'https://translate.google.' + {tld} + '/translate_a/single';
         var data = {
             client: opts.client || 't',
             sl: opts.from,
@@ -46,7 +47,7 @@ function translate(text, opts) {
         };
         data[token.name] = token.value;
 
-        return url.resolve(token.url, '/translate_a/single?' + querystring.stringify(data));
+        return url + '?' + querystring.stringify(data);
     }).then(function (url) {
         return got(url).then(function (res) {
             var result = {

--- a/languages.js
+++ b/languages.js
@@ -81,7 +81,7 @@ var langs = {
     'fa': 'Persian',
     'pl': 'Polish',
     'pt': 'Portuguese',
-    'ma': 'Punjabi',
+    'pa': 'Punjabi',
     'ro': 'Romanian',
     'ru': 'Russian',
     'sm': 'Samoan',

--- a/languages.js
+++ b/languages.js
@@ -22,6 +22,7 @@ var langs = {
     'ca': 'Catalan',
     'ceb': 'Cebuano',
     'ny': 'Chichewa',
+    'zh': 'Chinese Simplified',
     'zh-cn': 'Chinese Simplified',
     'zh-tw': 'Chinese Traditional',
     'co': 'Corsican',

--- a/languages.js
+++ b/languages.js
@@ -44,6 +44,7 @@ var langs = {
     'ht': 'Haitian Creole',
     'ha': 'Hausa',
     'haw': 'Hawaiian',
+    'he': 'Hebrew',
     'iw': 'Hebrew',
     'hi': 'Hindi',
     'hmn': 'Hmong',


### PR DESCRIPTION
Fixes applied to languages.js to allow for proper Punjabi translations and support for the usage of both `zh` and `zh-cn` language code in Simplified Chinese translations and both `he` and `iw` language codes in Hebrew translations, as well as to index.js to fix translation requests originating from China and allow for other language URLs to be used as well (this will fix issues #4, https://github.com/matheuss/google-translate-api/issues/48, https://github.com/matheuss/google-translate-api/issues/59, https://github.com/matheuss/google-translate-api/issues/60, https://github.com/matheuss/google-translate-api/issues/62, https://github.com/matheuss/google-translate-api/issues/68, and https://github.com/matheuss/google-translate-token/issues/10, tying into the PR @ https://github.com/vitalets/google-translate-token/pull/2, which has a better method of URL switching than https://github.com/vitalets/google-translate-token/pull/1 did).