### PR TITLE
Update index.js to allow for multiple URL support

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function translate(text, opts) {
     opts.to = languages.getCode(opts.to);
 
     return token.get(text).then(function (token) {
-        var tld = opts.tld = opts.tls || 'com';
+        opts.tld = opts.tls || 'com';
         var url = 'https://translate.google.' + opts.tld + '/translate_a/single';
         var data = {
             client: opts.client || 't',

--- a/index.js
+++ b/index.js
@@ -27,9 +27,9 @@ function translate(text, opts) {
 
     opts.from = languages.getCode(opts.from);
     opts.to = languages.getCode(opts.to);
+    opts.tld = opts.tls || 'com';
 
-    return token.get(text).then(function (token) {
-        opts.tld = opts.tls || 'com';
+    return token.get(opts, text).then(function (token) {
         var url = 'https://translate.google.' + opts.tld + '/translate_a/single';
         var data = {
             client: opts.client || 't',

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function translate(text, opts) {
     opts.to = languages.getCode(opts.to);
 
     return token.get(text).then(function (token) {
-        opts.tld = opts.tls || 'com';
+        var tld = opts.tld = opts.tls || 'com';
         var url = 'https://translate.google.' + opts.tld + '/translate_a/single';
         var data = {
             client: opts.client || 't',

--- a/index.js
+++ b/index.js
@@ -29,7 +29,8 @@ function translate(text, opts) {
     opts.to = languages.getCode(opts.to);
 
     return token.get(text).then(function (token) {
-        var url = 'https://translate.google.com/translate_a/single';
+        var tld = 'com';
+        var url = 'https://translate.google.' + {tld} + '/translate_a/single';
         var data = {
             client: opts.client || 't',
             sl: opts.from,

--- a/index.js
+++ b/index.js
@@ -29,8 +29,8 @@ function translate(text, opts) {
     opts.to = languages.getCode(opts.to);
 
     return token.get(text).then(function (token) {
-        var tld = 'com';
-        var url = 'https://translate.google.' + {tld} + '/translate_a/single';
+        opts.tld = opts.tls || 'com';
+        var url = 'https://translate.google.' + opts.tld + '/translate_a/single';
         var data = {
             client: opts.client || 't',
             sl: opts.from,

--- a/test.js
+++ b/test.js
@@ -142,3 +142,18 @@ test('translate from dutch to english using language names instead of codes', as
         t.fail(err.code);
     }
 });
+
+test('translate via custom tld', async t => {
+    try {
+        const res = await translate('vertaler', {tld: 'cn'});
+
+        t.is(res.text, 'translator');
+        t.false(res.from.language.didYouMean);
+        t.is(res.from.language.iso, 'nl');
+        t.false(res.from.text.autoCorrected);
+        t.is(res.from.text.value, '');
+        t.false(res.from.text.didYouMean);
+    } catch (err) {
+        t.fail(err.code);
+    }
+});


### PR DESCRIPTION
WIP update to index.js to allow for multiple URL support in the API by adding a new argument field (ties into PR https://github.com/vitalets/google-translate-token/pull/2). This fixes https://github.com/matheuss/google-translate-api/issues/60, https://github.com/matheuss/google-translate-token/issues/10 and part of issue #4.