### PR TITLE
Update index.js to allow for language additions from outside of the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,6 @@ translate('Ik spreek Engels', {to: 'en'}, {
 });
 ```
 
-## Does it work from web page context?
-No. `https://translate.google.com` does not provide [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) http headers allowing access from other domains.
-=======
 You can also add languages in the code and use them in the translation:
 
 ``` js
@@ -116,6 +113,9 @@ Gta = require('google-translate-api');
 Gta.languages['sr-Latn'] = 'Serbian Latin';
 Gta.languages['sr-Cyrl'] = 'Serbian Cyrillic';
 ```
+
+## Does it work from web page context?
+No. `https://translate.google.com` does not provide [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) http headers allowing access from other domains.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ translate('I spea Dutch!', {from: 'en', to: 'nl'}).then(res => {
 });
 ```
 
+You can also add languages in the code and use them in the translation:
+
+``` js
+Gta = require('google-translate-api');
+Gta.languages['sr-Latn'] = 'Serbian Latin';
+Gta.languages['sr-Cyrl'] = 'Serbian Cyrillic';
+```
+
 ## Too many requests
 Google Translate has request limits. If too many requests are made, you can either end up with a 429 or a 503 error.
 You can use proxy to bypass them:
@@ -104,14 +112,6 @@ translate('Ik spreek Engels', {to: 'en'}, {
 }).catch(err => {
     console.error(err);
 });
-```
-
-You can also add languages in the code and use them in the translation:
-
-``` js
-Gta = require('google-translate-api');
-Gta.languages['sr-Latn'] = 'Serbian Latin';
-Gta.languages['sr-Cyrl'] = 'Serbian Cyrillic';
 ```
 
 ## Does it work from web page context?

--- a/README.md
+++ b/README.md
@@ -21,8 +21,12 @@ This fork of original [matheuss/google-translate-api](https://github.com/matheus
 - Removed unsecure `unsafe-eval` dependency (See [#2](https://github.com/vitalets/google-translate-api/pull/2))
 - Added [daily CI tests](https://travis-ci.org/vitalets/google-translate-api/builds) to get notified if Google API changes
 - Added support for custom `tld` (especially to support `translate.google.cn`, see [#7](https://github.com/vitalets/google-translate-api/pull/7))
+<<<<<<< HEAD
 - Added support for outputting pronunciation (see [#17](https://github.com/vitalets/google-translate-api/pull/17))
 - Added support for custom [got](https://github.com/sindresorhus/got) options. It allows to use proxy and bypass request limits (see [#25](https://github.com/vitalets/google-translate-api/pull/25))
+=======
+- Added support for language extensions from outside of the API (See [#18](https://github.com/vitalets/google-translate-api/pull/18))
+>>>>>>> Update README.md
 
 ## Install 
 
@@ -82,6 +86,7 @@ translate('I spea Dutch!', {from: 'en', to: 'nl'}).then(res => {
 });
 ```
 
+<<<<<<< HEAD
 ## Too many requests
 Google Translate has request limits. If too many requests are made, you can either end up with a 429 or a 503 error.
 You can use proxy to bypass them:
@@ -107,6 +112,15 @@ translate('Ik spreek Engels', {to: 'en'}, {
 
 ## Does it work from web page context?
 No. `https://translate.google.com` does not provide [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) http headers allowing access from other domains.
+=======
+You can also add languages in the code and use them in the translation:
+
+``` js
+Gta = require('google-translate-api');
+Gta.languages['sr-Latn'] = 'Serbian Latin';
+Gta.languages['sr-Cyrl'] = 'Serbian Cyrillic';
+```
+>>>>>>> Update README.md
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,9 @@ This fork of original [matheuss/google-translate-api](https://github.com/matheus
 - Removed unsecure `unsafe-eval` dependency (See [#2](https://github.com/vitalets/google-translate-api/pull/2))
 - Added [daily CI tests](https://travis-ci.org/vitalets/google-translate-api/builds) to get notified if Google API changes
 - Added support for custom `tld` (especially to support `translate.google.cn`, see [#7](https://github.com/vitalets/google-translate-api/pull/7))
-<<<<<<< HEAD
 - Added support for outputting pronunciation (see [#17](https://github.com/vitalets/google-translate-api/pull/17))
 - Added support for custom [got](https://github.com/sindresorhus/got) options. It allows to use proxy and bypass request limits (see [#25](https://github.com/vitalets/google-translate-api/pull/25))
-=======
 - Added support for language extensions from outside of the API (See [#18](https://github.com/vitalets/google-translate-api/pull/18))
->>>>>>> Update README.md
 
 ## Install 
 
@@ -86,7 +83,6 @@ translate('I spea Dutch!', {from: 'en', to: 'nl'}).then(res => {
 });
 ```
 
-<<<<<<< HEAD
 ## Too many requests
 Google Translate has request limits. If too many requests are made, you can either end up with a 429 or a 503 error.
 You can use proxy to bypass them:
@@ -120,7 +116,6 @@ Gta = require('google-translate-api');
 Gta.languages['sr-Latn'] = 'Serbian Latin';
 Gta.languages['sr-Cyrl'] = 'Serbian Cyrillic';
 ```
->>>>>>> Update README.md
 
 ## API
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function translate(text, opts, gotopts) {
     gotopts = gotopts || {};
     var e;
     [opts.from, opts.to].forEach(function (lang) {
-        if (lang && !languages.isSupported(lang)) {
+        if (lang && !translate.languages.isSupported(lang)) {
             e = new Error();
             e.code = 400;
             e.message = 'The language \'' + lang + '\' is not supported';
@@ -26,8 +26,8 @@ function translate(text, opts, gotopts) {
     opts.to = opts.to || 'en';
     opts.tld = opts.tld || 'com';
 
-    opts.from = languages.getCode(opts.from);
-    opts.to = languages.getCode(opts.to);
+    opts.from = translate.languages.getCode(opts.from);
+    opts.to = translate.languages.getCode(opts.to);
 
     return token.get(text, {tld: opts.tld}).then(function (token) {
         var url = 'https://translate.google.' + opts.tld + '/translate_a/single';
@@ -117,4 +117,4 @@ function translate(text, opts, gotopts) {
 }
 
 module.exports = translate;
-module.exports.languages = languages;
+translate.languages = languages;

--- a/test.js
+++ b/test.js
@@ -145,6 +145,7 @@ test('translate via custom tld', async t => {
 test('translate via an external language from outside of the API', async t => {
     const res = await translate('vertaler');
     const lang = await translate.languages['sr-Latn'] = 'Serbian Latin';
+    
     t.is(res.text, 'translator');
     t.false(res.from.language.didYouMean);
     t.is(res.from.language.iso, 'sr-Latn');

--- a/test.js
+++ b/test.js
@@ -142,6 +142,17 @@ test('translate via custom tld', async t => {
     t.false(res.from.text.didYouMean);
 });
 
+test('translate via an external language from outside of the API', async t => {
+    const res = await translate('vertaler');
+    const lang = await translate.languages['sr-Latn'] = 'Serbian Latin';
+    t.is(res.text, 'translator');
+    t.false(res.from.language.didYouMean);
+    t.is(res.from.language.iso, 'sr-Latn');
+    t.false(res.from.text.autoCorrected);
+    t.is(res.from.text.value, '');
+    t.false(res.from.text.didYouMean);
+}
+
 test('pass got options', async t => {
     let a = 0;
     const gotopts = {

--- a/test.js
+++ b/test.js
@@ -144,7 +144,7 @@ test('translate via custom tld', async t => {
 
 test('translate via an external language from outside of the API', async t => {
     const res = await translate('vertaler');
-    const lang = await translate.languages['sr-Latn'] = 'Serbian Latin';
+    const lang = await translate.languages(['sr-Latn'] = 'Serbian Latin');
     
     t.is(res.text, 'translator');
     t.false(res.from.language.didYouMean);


### PR DESCRIPTION
Updates index.js to allow for language additions from outside of the API (carryover from unmaintained upstream PR https://github.com/matheuss/google-translate-api/pull/31).