### PR TITLE
Update `translit` field

### DIFF
--- a/response-sample.json
+++ b/response-sample.json
@@ -11,7 +11,7 @@
       "backend": 10
     },
     {
-      "src_translit": "Privet, mir! Kak dela?"
+      "translit": "Privet, mir! Kak dela?"
     }
   ],
   "src": "ru",


### PR DESCRIPTION
Apparently the API response has changed and it the transliteration field got renamed from `src_translit` to `translit`


Example response
```{
    "sentences": [
        {
            "trans": "Здраво, како си",
            "orig": "hello how are you",
            "backend": 1
        },
        {
            "translit": "Zdravo, kako si"
        }
    ],
    "src": "en",
    "confidence": 1.0,
    "spell": {},
    "ld_result": {
        "srclangs": [
            "en"
        ],
        "srclangs_confidences": [
            1.0
        ],
        "extended_srclangs": [
            "en"
        ]
    }
}
```